### PR TITLE
fix(*): Remove keystore.jks

### DIFF
--- a/kafka-consumers/solutions/plain/src/main/java/com/redhat/telemetry/ConsumerApp.java
+++ b/kafka-consumers/solutions/plain/src/main/java/com/redhat/telemetry/ConsumerApp.java
@@ -37,8 +37,6 @@ public class ConsumerApp
         props.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, "org.apache.kafka.common.serialization.StringDeserializer");
         props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, "org.apache.kafka.common.serialization.IntegerDeserializer");
         props.put(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG, "SSL");
-        props.put(SslConfigs.SSL_KEYSTORE_LOCATION_CONFIG, "/PATH/TO/keystore.jks");
-        props.put(SslConfigs.SSL_KEYSTORE_PASSWORD_CONFIG, "password");
         props.put(SslConfigs.SSL_TRUSTSTORE_LOCATION_CONFIG, "/PATH/TO/truststore.jks");
         props.put(SslConfigs.SSL_TRUSTSTORE_PASSWORD_CONFIG, "password");
 

--- a/kafka-consumers/solutions/quarkus/src/main/resources/application.properties
+++ b/kafka-consumers/solutions/quarkus/src/main/resources/application.properties
@@ -6,7 +6,5 @@ mp.messaging.incoming.humidityConditions.group.id=humidityMonitoring
 
 kafka.bootstrap.servers=my-cluster-kafka-bootstrap-youruser-kafka-cluster.apps.cluster.example.com:443
 kafka.security.protocol=SSL
-kafka.ssl.keystore.location=/ABSOLUTE_PATH_TO_YOUR_WORKSPACE_FOLDER/keystore.jks
-kafka.ssl.keystore.password=password
 kafka.ssl.truststore.location=/ABSOLUTE_PATH_TO_YOUR_WORKSPACE_FOLDER/truststore.jks
 kafka.ssl.truststore.password=password

--- a/kafka-producers/solutions/plain/producer/src/main/java/com/redhat/telemetry/producer/ProducerApp.java
+++ b/kafka-producers/solutions/plain/producer/src/main/java/com/redhat/telemetry/producer/ProducerApp.java
@@ -33,11 +33,6 @@ public class ProducerApp {
         // @todo: configure the SSL connection
         props.put(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG, "SSL");
         props.put(
-                SslConfigs.SSL_KEYSTORE_LOCATION_CONFIG,
-                "ABSOLUTE_PATH_TO_WORKSPACE_FOLDER/keystore.jks"
-        );
-        props.put(SslConfigs.SSL_KEYSTORE_PASSWORD_CONFIG, "password");
-        props.put(
                 SslConfigs.SSL_TRUSTSTORE_LOCATION_CONFIG,
                 "ABSOLUTE_PATH_TO_WORKSPACE_FOLDER/truststore.jks"
         );

--- a/kafka-producers/solutions/quarkus/src/main/resources/application.properties
+++ b/kafka-producers/solutions/quarkus/src/main/resources/application.properties
@@ -7,8 +7,6 @@ mp.messaging.outgoing.device-temperatures.value.serializer = org.apache.kafka.co
 
 # @todo: configure the SSL connection
 kafka.security.protocol = SSL
-kafka.ssl.keystore.location = ABSOLUTE_PATH_TO_WORKSPACE_FOLDER/keystore.jks
-kafka.ssl.keystore.password = password
 kafka.ssl.truststore.location = ABSOLUTE_PATH_TO_WORKSPACE_FOLDER/truststore.jks
 kafka.ssl.truststore.password = password
 


### PR DESCRIPTION
This PR removes keystores since truststore.jks is enough for ssl handshake (there is not sasl auth in our cases)

Please try the apps out again just for the double-check.

Another PR is created for the section GE:

https://github.com/RedHatTraining/AD482/pull/162