### PR TITLE
fix(ch05s09): Add Windows support to Quarkus apps

### DIFF
--- a/connect-integration/apps/incidents-archive-service/pom.xml
+++ b/connect-integration/apps/incidents-archive-service/pom.xml
@@ -89,6 +89,13 @@
                         </goals>
                     </execution>
                 </executions>
+                <dependencies>
+                    <dependency>
+                        <groupId>jline</groupId>
+                        <artifactId>jline</artifactId>
+                        <version>2.14.6</version>
+                    </dependency>
+                </dependencies>
             </plugin>
         </plugins>
     </build>

--- a/connect-integration/apps/plumber-service/pom.xml
+++ b/connect-integration/apps/plumber-service/pom.xml
@@ -101,6 +101,13 @@
                         </goals>
                     </execution>
                 </executions>
+                <dependencies>
+                    <dependency>
+                        <groupId>jline</groupId>
+                        <artifactId>jline</artifactId>
+                        <version>2.14.6</version>
+                    </dependency>
+                </dependencies>
             </plugin>
         </plugins>
     </build>

--- a/connect-integration/apps/repair-request-service/pom.xml
+++ b/connect-integration/apps/repair-request-service/pom.xml
@@ -104,6 +104,13 @@
                         </goals>
                     </execution>
                 </executions>
+                <dependencies>
+                    <dependency>
+                        <groupId>jline</groupId>
+                        <artifactId>jline</artifactId>
+                        <version>2.14.6</version>
+                    </dependency>
+                </dependencies>
             </plugin>
         </plugins>
     </build>

--- a/connect-integration/solutions/incidents-archive-service/pom.xml
+++ b/connect-integration/solutions/incidents-archive-service/pom.xml
@@ -89,6 +89,13 @@
                         </goals>
                     </execution>
                 </executions>
+                <dependencies>
+                    <dependency>
+                        <groupId>jline</groupId>
+                        <artifactId>jline</artifactId>
+                        <version>2.14.6</version>
+                    </dependency>
+                </dependencies>
             </plugin>
         </plugins>
     </build>

--- a/connect-integration/solutions/plumber-service/pom.xml
+++ b/connect-integration/solutions/plumber-service/pom.xml
@@ -101,6 +101,13 @@
                         </goals>
                     </execution>
                 </executions>
+                <dependencies>
+                    <dependency>
+                        <groupId>jline</groupId>
+                        <artifactId>jline</artifactId>
+                        <version>2.14.6</version>
+                    </dependency>
+                </dependencies>
             </plugin>
         </plugins>
     </build>

--- a/connect-integration/solutions/repair-request-service/pom.xml
+++ b/connect-integration/solutions/repair-request-service/pom.xml
@@ -104,6 +104,13 @@
                         </goals>
                     </execution>
                 </executions>
+                <dependencies>
+                    <dependency>
+                        <groupId>jline</groupId>
+                        <artifactId>jline</artifactId>
+                        <version>2.14.6</version>
+                    </dependency>
+                </dependencies>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
In Windows, Quarkus 2.1.4 requires the jline dependency